### PR TITLE
Update d6t-32l.ino : Fix: Add missing return statement in i2c_read_reg8

### DIFF
--- a/examples/d6t-32l/d6t-32l.ino
+++ b/examples/d6t-32l/d6t-32l.ino
@@ -218,6 +218,7 @@ bool i2c_read_reg8(uint8_t addr7, uint8_t reg, uint8_t* buf, int n) {
     buf[n - 1] = i2c_read_8cycles();
     i2c_read_ack_cycle(OC_NACK);
     i2c_stop();
+    return false;
 }
 
 #undef W


### PR DESCRIPTION
Fix: Add missing return statement in i2c_read_reg8 to avoid crashes on ESP32.
returnが無い状態で、ESP32用にビルドしたところ、リブートを繰り返していました。
Arduino-IDEのESP32ボードライブラリは現在最新の3.2.0で試しました。